### PR TITLE
inspect throwing exceptions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -131,6 +131,4 @@ reports/
 
 target/
 
-.bash_profile
-
 compiler-plugin/src/main/kotlin/arrow/meta/services

--- a/.gitignore
+++ b/.gitignore
@@ -132,3 +132,5 @@ reports/
 target/
 
 .bash_profile
+
+compiler-plugin/src/main/kotlin/arrow/meta/services

--- a/app/src/main/java/arrow/sample/TestClass.kt
+++ b/app/src/main/java/arrow/sample/TestClass.kt
@@ -1,20 +1,31 @@
 package arrow.sample
 
 class TestClass {
-  fun sideEffect() =
+  /*fun sideEffect() =
     println("BOOM!")
 
   suspend fun other(): Unit {
     println("other")
+  }*/
+
+  var d = {
+    // wrap anonymous fun into suspend
+    //if(4 > 0)
+    //  throw RuntimeException("Damn") // and add Ex.raiseError()
+    3
   }
 
-  val x = { println() }
+  fun s(): String {
+    d = { d() - 2 }
+    return "p"
+  }
+  // val x = { println() }
 
-  fun another2(): String {
+  /*fun another2(): String {
     1; println("test");
     {
       { println() }
     }()
     return "another"
-  }
+  }*/
 }

--- a/app/src/main/java/arrow/sample/TestClass.kt
+++ b/app/src/main/java/arrow/sample/TestClass.kt
@@ -1,17 +1,16 @@
 package arrow.sample
 
 class TestClass {
-  /*fun sideEffect() =
+  fun sideEffect() =
     println("BOOM!")
 
   suspend fun other(): Unit {
     println("other")
-  }*/
+  }
 
-  var d = {
-    // wrap anonymous fun into suspend
-    //if(4 > 0)
-    //  throw RuntimeException("Damn") // and add Ex.raiseError()
+  var d: () -> Int = {
+    if (true)
+      throw RuntimeException("Damn")
     3
   }
 
@@ -19,13 +18,14 @@ class TestClass {
     d = { d() - 2 }
     return "p"
   }
-  // val x = { println() }
 
-  /*fun another2(): String {
+  val x = { println() }
+
+  fun another2(): String {
     1; println("test");
     {
       { println() }
     }()
     return "another"
-  }*/
+  }
 }


### PR DESCRIPTION
Further improvements on the pure plugin:
- matching on the `throw` keyword, which is not in a suspended environment
